### PR TITLE
Fix motion imports to motion/react in modal components

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion";
+import { motion } from "motion/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 

--- a/components/SharedModal.tsx
+++ b/components/SharedModal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { AnimatePresence, MotionConfig, motion } from "framer-motion";
 import {
   ArrowLeft,
   ChevronLeft,
@@ -8,6 +7,7 @@ import {
   ExternalLink,
   X,
 } from "lucide-react";
+import { AnimatePresence, MotionConfig, motion } from "motion/react";
 import Image from "next/image";
 import { useState } from "react";
 import { useSwipeable } from "react-swipeable";


### PR DESCRIPTION
Fixes the issue where Motion React components (motion, AnimatePresence, MotionConfig) were imported from legacy paths by updating them to `motion/react`. Tested with `pnpm check`, `pnpm build`, and verified via visual modal verification screenshot.

---
*PR created automatically by Jules for task [5202424208106455429](https://jules.google.com/task/5202424208106455429) started by @torn4dom4n*